### PR TITLE
Avoids a blank logfile if running --help or -h

### DIFF
--- a/team51-user-removal.sh
+++ b/team51-user-removal.sh
@@ -19,9 +19,7 @@ summary_only=false
 success_count=0
 failure_count=0
 failed_emails=()
-
-# Create the log file
-> "$log_file"
+create_log=true
 
 # Function to display help information
 show_help() {
@@ -164,6 +162,8 @@ show_summary() {
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -h|--help)
+            # Don't create a logfile for help commands
+            create_log=false
             show_help
             ;;
         -e|--email)
@@ -192,6 +192,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -n|--no-log)
+            create_log=false
             log_file=""
             shift
             ;;
@@ -205,6 +206,11 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# Create the log file if needed
+if [[ "$create_log" = true && -n "$log_file" ]]; then
+    > "$log_file"
+fi
 
 # If no emails provided, prompt for them
 if [[ ${#emails[@]} -eq 0 ]]; then


### PR DESCRIPTION
When running `./team51-user-removal.sh --help` or `./team51-user-removal.sh -h`, a blank logfile would be created with no output. This moves the logfile creation around and fixes that issue.